### PR TITLE
Clones blocks placed near original block

### DIFF
--- a/src/main/java/edu/mit/blocks/renderable/RenderableBlock.java
+++ b/src/main/java/edu/mit/blocks/renderable/RenderableBlock.java
@@ -1807,6 +1807,10 @@ public class RenderableBlock extends JComponent implements SearchableElement,
 			renderable.comment.setLocation(renderable.comment.getLocation());
 			renderable.comment.getArrow().updateArrow();
 		}
+	// When dragging, Child blocks can become mis-aligned to their Parent Block which is very annoying
+	// I can't stop this happening, nor work out why it happens.
+	// This is just a quick 'fix' to stop things looking too bad
+	renderable.moveConnectedBlocks();
 	}
 
 	private void drag(RenderableBlock renderable, int dx, int dy,

--- a/src/main/java/edu/mit/blocks/renderable/RenderableBlock.java
+++ b/src/main/java/edu/mit/blocks/renderable/RenderableBlock.java
@@ -1624,6 +1624,8 @@ public class RenderableBlock extends JComponent implements SearchableElement,
     	Block oriBlock = rb.getBlock();
     	oriBlock.getSockets();
     	
+    	Point oriLocation =rb.getLocation();
+    	
     	Block newBlock = new Block(workspace, rb.getGenus(), rb.blockLabel.getText());
     	RenderableBlock newRb = new RenderableBlock(workspace, parent, newBlock.getBlockID(), false);
     	
@@ -1677,6 +1679,8 @@ public class RenderableBlock extends JComponent implements SearchableElement,
     		}
     	}
     	
+    	newRb.setLocation(oriLocation.x+(int)(NEARBY_RADIUS),oriLocation.y+(int)(NEARBY_RADIUS));
+    	newRb.moveConnectedBlocks();
     	parent.addBlock(newRb);
     	newRb.linkedDefArgsBefore = true;
     	return newRb;


### PR DESCRIPTION
Cloned blocks are placed near original blocks NOT at top left of workspace.
Useful anyway but especially in large sketches, ie bigger than screen
size. where top left of workspace is not even on screen.

Quick fix for ardublock issue #59 "Blocks get un-attached"
